### PR TITLE
Feat: Support for 1-arg methods in constructAnySetter() 

### DIFF
--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
@@ -406,7 +406,12 @@ public class BeanDeserializer
                 handleUnknownVanilla(p, ctxt, bean, propName);
             } while ((propName = p.nextFieldName()) != null);
             if(_anySetter != null) {
-                _anySetter.parsingDone(bean);
+                try{
+                    _anySetter.parsingDone(bean);
+                }catch(Exception e){
+                    wrapAndThrow(e, bean, propName, ctxt);
+                }                
+
             }
         }
         return bean;

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
@@ -405,6 +405,9 @@ public class BeanDeserializer
                 }
                 handleUnknownVanilla(p, ctxt, bean, propName);
             } while ((propName = p.nextFieldName()) != null);
+            if(_anySetter != null) {
+                _anySetter.parsingDone(bean);
+            }
         }
         return bean;
     }

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializer.java
@@ -405,6 +405,9 @@ public class BeanDeserializer
                 }
                 handleUnknownVanilla(p, ctxt, bean, propName);
             } while ((propName = p.nextFieldName()) != null);
+            // This code is for 1-arg of type map anysetter methods
+            // Indicates that the parsing is done and that the 1-arg method can be called 
+            // with the map of unmapped properties. 
             if(_anySetter != null) {
                 try{
                     _anySetter.parsingDone(bean);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/BeanDeserializerFactory.java
@@ -842,18 +842,31 @@ ClassUtil.name(name), ((AnnotatedParameter) m).getIndex());
         final boolean isField = mutator instanceof AnnotatedField;
         // [databind#562] Allow @JsonAnySetter on Creator constructor
         final boolean isParameter = mutator instanceof AnnotatedParameter;
+        boolean isMapMethod = false; 
         int parameterIndex = -1;
 
         if (mutator instanceof AnnotatedMethod) {
-            // we know it's a 2-arg method, second arg is the value
             AnnotatedMethod am = (AnnotatedMethod) mutator;
-            keyType = am.getParameterType(0);
-            valueType = am.getParameterType(1);
-            // Need to resolve for possible generic types (like Maps, Collections)
-            valueType = resolveMemberAndTypeAnnotations(ctxt, mutator, valueType);
-            prop = new BeanProperty.Std(PropertyName.construct(mutator.getName()),
-                    valueType, null, mutator,
-                    PropertyMetadata.STD_OPTIONAL);
+            // It can either be a 2-arg method or 1-arg of type Map. 
+            if(am.getParameterCount() == 1){
+                JavaType paramType = am.getParameterType(0);
+                paramType = resolveMemberAndTypeAnnotations(ctxt, am, paramType);
+                keyType = paramType.getKeyType();
+                valueType = paramType.getContentType();
+                prop =  new BeanProperty.Std(PropertyName.construct(mutator.getName()),
+                paramType, null, mutator, PropertyMetadata.STD_OPTIONAL);
+                isMapMethod = true; 
+            }
+            // we know it's a 2-arg method, second arg is the value
+            else{
+                keyType = am.getParameterType(0);
+                valueType = am.getParameterType(1);
+                // Need to resolve for possible generic types (like Maps, Collections)
+                valueType = resolveMemberAndTypeAnnotations(ctxt, mutator, valueType);
+                prop = new BeanProperty.Std(PropertyName.construct(mutator.getName()),
+                        valueType, null, mutator,
+                        PropertyMetadata.STD_OPTIONAL);
+            }
 
         } else if (isField) {
             AnnotatedField af = (AnnotatedField) mutator;
@@ -951,6 +964,9 @@ ClassUtil.name(name), ((AnnotatedParameter) m).getIndex());
         if (isParameter) {
             return SettableAnyProperty.constructForMapParameter(ctxt,
                     prop, mutator, valueType, keyDeser, deser, typeDeser, parameterIndex);
+        }
+        if(isMapMethod){
+            return SettableAnyProperty.constructForMapMethod(ctxt, prop, mutator, valueType, keyDeser, deser, typeDeser);
         }
         return SettableAnyProperty.constructForMethod(ctxt,
                 prop, mutator, valueType, keyDeser, deser, typeDeser);

--- a/src/main/java/com/fasterxml/jackson/databind/deser/SettableAnyProperty.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/SettableAnyProperty.java
@@ -87,6 +87,18 @@ public abstract class SettableAnyProperty
     }
 
     /**
+     * @since 2.19
+     */
+    public static SettableAnyProperty constructForMapMethod(DeserializationContext ctxt,
+            BeanProperty property,
+            AnnotatedMember field, JavaType valueType,
+            KeyDeserializer keyDeser,
+            JsonDeserializer<Object> valueDeser, TypeDeserializer typeDeser) {
+        return new MapMethodAnyProperty(property, field, valueType,
+                keyDeser, valueDeser, typeDeser);
+    }
+
+    /**
      * @since 2.14
      */
     public static SettableAnyProperty constructForMapField(DeserializationContext ctxt,
@@ -270,6 +282,9 @@ public abstract class SettableAnyProperty
 
     protected abstract void _set(Object instance, Object propName, Object value) throws Exception;
 
+    public void parsingDone(Object instance) throws Exception {}
+
+
     /*
     /**********************************************************
     /* Helper methods
@@ -339,6 +354,32 @@ public abstract class SettableAnyProperty
     /* Concrete implementations
     /**********************************************************************
      */
+
+    /**
+     * @since 2.19
+     */
+    protected static class MapMethodAnyProperty extends SettableAnyProperty implements java.io.Serializable {
+        Map<Object, Object> map;
+
+        public MapMethodAnyProperty(BeanProperty property, AnnotatedMember setter, JavaType type, KeyDeserializer keyDeser, JsonDeserializer<Object> valueDeser, TypeDeserializer typeDeser) {
+            super(property, setter, type, keyDeser, valueDeser, typeDeser);
+        }
+
+        @Override
+        public SettableAnyProperty withValueDeserializer(JsonDeserializer<Object> deser) {
+            return new MapMethodAnyProperty(_property, _setter, _type, _keyDeserializer, deser, _valueTypeDeserializer);
+        }
+
+        @Override
+        protected void _set(Object instance, Object propName, Object value)  {
+            map.put(propName, value);
+        }
+
+        @Override
+        public void parsingDone(Object instance) throws Exception {
+            ((AnnotatedMethod) _setter).callOnWith(instance, map);
+        }
+    }
 
     /**
      * @since 2.14

--- a/src/main/java/com/fasterxml/jackson/databind/deser/SettableAnyProperty.java
+++ b/src/main/java/com/fasterxml/jackson/databind/deser/SettableAnyProperty.java
@@ -359,7 +359,7 @@ public abstract class SettableAnyProperty
      * @since 2.19
      */
     protected static class MapMethodAnyProperty extends SettableAnyProperty implements java.io.Serializable {
-        Map<Object, Object> map;
+        Map<Object, Object> map = new HashMap<>();
 
         public MapMethodAnyProperty(BeanProperty property, AnnotatedMember setter, JavaType type, KeyDeserializer keyDeser, JsonDeserializer<Object> valueDeser, TypeDeserializer typeDeser) {
             super(property, setter, type, keyDeser, valueDeser, typeDeser);


### PR DESCRIPTION
Adds support for 1-arg methods in the constructAnySetter. If constructAnySetter is called with a 1-arg method it will return an instance of MapMethodAnyProperty.  The method currently does not check the types of the arguments as it assumes it has been done in previous steps. 


Closes #8 